### PR TITLE
101 dockerhub throttle

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This template will set up:
      - `GithubLink`: Default repository for the Agent (do not change)
      - `ImageTag`: Tag of the Docker image for Streamlit UI deployment
      - `MultiAgentDevMode`: Select True to use a python notebook to manually create the agents step by step. Select false to auto create a subset of agents.
-     - `ReactAppAllowedCidr`: CIDR range from where access to the React UI is allowed. Learn about best practices in the AWS VPC [documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html).
+     - `ReactAppAllowedCidr`: CIDR range from where access to the React UI is allowed. Learn about best practices in the AWS VPC [documentation](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html). To restrict React App UI access to just your IP, find your IP address through public websites such as [WhatIsMyIpAddress](https://whatismyipaddress.com/) and suffix it with `32`. For example, `1.2.3.4/32`
  
 3. After stack launch is successful manually sync the Knowledgebase:
    1. Navigate to the Bedrock dashboard via AWS Console search

--- a/ui/Dockerfile
+++ b/ui/Dockerfile
@@ -1,5 +1,5 @@
 # Step 1: Use Node.js base image
-FROM --platform=linux/amd64 node:18-alpine AS builder
+FROM --platform=linux/amd64 public.ecr.aws/docker/library/node:18-alpine3.21 AS builder
 
 # Set working directory
 WORKDIR /app
@@ -13,7 +13,7 @@ COPY . .
 RUN npm run build
 
 # Step 2: Create a lightweight production image
-FROM --platform=linux/amd64 node:18-alpine
+FROM --platform=linux/amd64 public.ecr.aws/docker/library/node:18-alpine3.21
 
 WORKDIR /app
 


### PR DESCRIPTION
*Issue #, if available:* 101

*Description of changes:* Use node18 from ecr public instead of dockerhub to prevent throttling, updated README to make CIDR instructions user friendly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
