### PR TITLE
Fixed naming of evaluation repo

### DIFF
--- a/evaluations/evaluate_biomarker_agent.ipynb
+++ b/evaluations/evaluate_biomarker_agent.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "# Evaluate Biomarker Supervisor Agent\n",
-    "In this notebook we evaluate the Biomarker Supervisor Agent using the [Bedrock Agent Evaluation Framework](https://github.com/aws-samples/amazon-bedrock-agent-evaluation-framework/tree/main)"
+    "In this notebook we evaluate the Biomarker Supervisor Agent using [Open Source Bedrock Agent Evaluation](https://github.com/aws-samples/open-source-bedrock-agent-evaluation)"
    ]
   },
   {
@@ -34,7 +34,7 @@
    "id": "207e9d10-4c32-44e2-8ee3-c88d74db69f6",
    "metadata": {},
    "source": [
-    "### Step 1: Clone the [Bedrock Agent Evaluation Framework](https://github.com/aws-samples/amazon-bedrock-agent-evaluation-framework/tree/main)"
+    "### Step 1: Clone [Open Source Bedrock Agent Evaluation](https://github.com/aws-samples/open-source-bedrock-agent-evaluation)"
    ]
   },
   {
@@ -44,7 +44,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!git clone https://github.com/aws-samples/amazon-bedrock-agent-evaluation-framework.git"
+    "!git clone https://github.com/aws-samples/open-source-bedrock-agent-evaluation.git"
    ]
   },
   {
@@ -96,7 +96,7 @@
     "from string import Template\n",
     "\n",
     "# Read the template file from the Bedrock Agent Evaluation Framework\n",
-    "template_file_path = os.path.join('amazon-bedrock-agent-evaluation-framework', 'config.env.tpl')\n",
+    "template_file_path = os.path.join('open-source-bedrock-agent-evaluation', 'config.env.tpl')\n",
     "with open(template_file_path, 'r') as template_file:\n",
     "    template_content = template_file.read()\n",
     "\n",
@@ -124,11 +124,11 @@
     "    config_content += f\"{key}={value}\\n\"\n",
     "\n",
     "# Write to config.env file in the correct folder\n",
-    "config_file_path = os.path.join('amazon-bedrock-agent-evaluation-framework', 'config.env')\n",
+    "config_file_path = os.path.join('open-source-bedrock-agent-evaluation', 'config.env')\n",
     "with open(config_file_path, 'w') as config_file:\n",
     "    config_file.write(config_content)\n",
     "\n",
-    "print(f\"config.env file has been created successfully in amazon-bedrock-agent-evaluation-framework!\")"
+    "print(f\"config.env file has been created successfully in open-source-bedrock-agent-evaluation!\")"
    ]
   },
   {

--- a/evaluations/execute_eval.sh
+++ b/evaluations/execute_eval.sh
@@ -10,7 +10,7 @@ echo "Bash configuration loaded"
 echo "--------------------------------------"
 
 echo "Changing to evaluation framework directory..."
-cd amazon-bedrock-agent-evaluation-framework
+cd open-source-bedrock-agent-evaluation
 echo "Directory changed successfully"
 echo "--------------------------------------"
 


### PR DESCRIPTION
Changed from 'amazon-bedrock-agent-evaluation-framework' to new evaluation repo name 'open-source-bedrock-agent-evaluation' in evaluation notebook and evaluation script
