### PR TITLE
redshift cluster instance type

### DIFF
--- a/Infra_cfn.yaml
+++ b/Infra_cfn.yaml
@@ -87,7 +87,7 @@ Resources:
     Properties:
       DBName: !Ref RedshiftDatabaseName
       ClusterIdentifier: biomarker-redshift-cluster
-      NodeType: dc2.large
+      NodeType: ra3.large
       MasterUsername: !Ref RedshiftUserName
       MasterUserPassword: !Ref RedshiftPassword
       ClusterType: single-node


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
dc2 instance not available anymore for redshift https://repost.aws/questions/QUiE6_K91vQEGMxqZPac6POA/unable-to-reserve-dc2-large-instance-for-redshift-only-ra3

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
